### PR TITLE
Upgrade kotlinVersion to 1.3.20 and made versions overridable to mitigate future build errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,9 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : '1.3.20'
 
     repositories {
         jcenter()
@@ -8,7 +12,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.3.1'
     }
 }
 
@@ -17,11 +21,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 27)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Hi, this PR upgrades kotlinVersion to 1.3.20 in order for the project to build with RN59.
Additionally, I've made the version numbers overridable, so that this library will be more resilient to version changes, as it uses the versions as defined in your main react-native app.